### PR TITLE
fix: addDays(0) for failed words + generate-words.ts copy-paste errors

### DIFF
--- a/lib/__tests__/correctionWords.test.ts
+++ b/lib/__tests__/correctionWords.test.ts
@@ -91,11 +91,11 @@ describe("processAnswer", () => {
       expect(result.easeFactor).toBe(parseFloat((DEFAULT_EASE_FACTOR - 0.15).toFixed(2))); // 2.35
     });
 
-    it("schedules review for the next day (addDays -1)", () => {
-      const word = createWord({ easeFactor: 2.5 });
-      const result = processAnswer(word, false);
+		it("schedules review for immediately (addDays 0)", () => {
+			const word = createWord({ easeFactor: 2.5 });
+			const result = processAnswer(word, false);
 
-      expect(toDate(result.nextReview)).toBe(daysFromNow(-1));
+			expect(toDate(result.nextReview)).toBe(daysFromNow(0));
     });
 
     it("sets lastReviewed to current time", () => {

--- a/lib/ai/generate-words.ts
+++ b/lib/ai/generate-words.ts
@@ -5,62 +5,62 @@ import { createAIClient } from "./client";
 const MODEL_NAME = process.env.AI_MODEL || "gemini-2.5-flash";
 
 export async function generateWords(
-  words: Word[],
-  level: number,
-  learningLanguage: Language,
-  userLanguage: Language,
+	words: Word[],
+	level: number,
+	learningLanguage: Language,
+	userLanguage: Language,
 ): Promise<WordsGeneratorResponse> {
-  try {
-    if (level < 1 || level > 100) {
-      throw new Error("Level must be between 1 and 100");
-    }
+	try {
+		if (level < 1 || level > 100) {
+			throw new Error("Level must be between 1 and 100");
+		}
 
-    const client = createAIClient();
+		const client = createAIClient();
 
-    const promptConfig = WORDS_PROMPTS[userLanguage];
-    if (!promptConfig) {
-      throw new Error(`Unsupported user language: ${userLanguage}`);
-    }
+		const promptConfig = WORDS_PROMPTS[userLanguage];
+		if (!promptConfig) {
+			throw new Error(`Unsupported user language: ${userLanguage}`);
+		}
 
-    const systemPrompt = promptConfig.systemPrompt();
-    const userPrompt = promptConfig.userPrompt(words, level, learningLanguage, userLanguage);
-    const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
+		const systemPrompt = promptConfig.systemPrompt();
+		const userPrompt = promptConfig.userPrompt(words, level, learningLanguage, userLanguage);
+		const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
 
-    // TODO: Separate the response_format  and add it to the options here
-    const result = await client.generateContent({
-      model: MODEL_NAME,
-      contents: fullPrompt,
-      config: {
-        temperature: 0.7,
-        topK: 40,
-        topP: 0.9,
-        responseMimeType: "application/json",
-      },
-    });
+		// TODO: Separate the response_format and add it to the options here
+		const result = await client.generateContent({
+			model: MODEL_NAME,
+			contents: fullPrompt,
+			config: {
+				temperature: 0.7,
+				topK: 40,
+				topP: 0.9,
+				responseMimeType: "application/json",
+			},
+		});
 
-    const responseText = result.text;
+		const responseText = result.text;
 
-    try {
-      const parsedResponse = JSON.parse(responseText) as WordsGeneratorResponse;
+		try {
+			const parsedResponse = JSON.parse(responseText) as WordsGeneratorResponse;
 
-      if (!parsedResponse.words || !Array.isArray(parsedResponse.words)) {
-        throw new Error("Response missing quizzes array");
-      }
+			if (!parsedResponse.words || !Array.isArray(parsedResponse.words)) {
+				throw new Error("Response missing words array");
+			}
 
-      parsedResponse.words.forEach((word, index) => {
-        if (!word.definition || !word.language || !word.phoneticNotation) {
-          throw new Error(`Quiz ${index + 1} missing required fields (dfinition, language, proneticNotation)`);
-        }
-      });
+			parsedResponse.words.forEach((word, index) => {
+				if (!word.definition || !word.language || !word.phoneticNotation) {
+					throw new Error(`Word ${index + 1} missing required fields (definition, language, phoneticNotation)`);
+				}
+			});
 
-      return parsedResponse;
-    } catch (parseError) {
-      console.error("Failed to parse JSON response:", parseError);
-      console.error("Response text:", responseText);
-      throw new Error(`Failed to parse quiz response: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
-    }
-  } catch (error) {
-    console.error("Error generating words:", error);
-    throw new Error(`Failed to generate quiz: ${error instanceof Error ? error.message : String(error)}`);
-  }
+			return parsedResponse;
+		} catch (parseError) {
+			console.error("Failed to parse JSON response:", parseError);
+			console.error("Response text:", responseText);
+			throw new Error(`Failed to parse words response: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
+		}
+	} catch (error) {
+		console.error("Error generating words:", error);
+		throw new Error(`Failed to generate words: ${error instanceof Error ? error.message : String(error)}`);
+	}
 }

--- a/lib/correctionWords.ts
+++ b/lib/correctionWords.ts
@@ -29,7 +29,7 @@ export const processAnswer = (word: Word, isCorrect: boolean, originalEaseFactor
     }
 
     updated.easeFactor = parseFloat(Math.max(MIN_EASE_FACTOR, newEase).toFixed(2));
-    updated.nextReview = addDays(new Date(), -1).toISOString();
+	updated.nextReview = addDays(new Date(), 0).toISOString();
   } else {
     updated.repetitions = word.repetitions + 1;
     updated.easeFactor = parseFloat(((word.easeFactor || DEFAULT_EASE_FACTOR) + 0.05).toFixed(2));


### PR DESCRIPTION
- Change addDays(-1) to addDays(0) in correctionWords.ts so failed words are immediately available for re-review the same day (not yesterday)
- Fix generate-words.ts error messages that referenced 'quiz' instead of 'words' (copy-paste from generate-quiz.ts)
- Fix typos in field names: 'dfinition' -> 'definition', 'proneticNotation' -> 'phoneticNotation'
- Update test to match addDays(0) behavior