### PR TITLE
feat: add AI provider fallback (Gemini → Nvidia)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,15 +10,17 @@ GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # -- AI Provider ------------------------------------------
-# Choose one or both. The app uses the first available key.
+# Configure one or both providers. When both are set, Gemini is primary
+# and Nvidia is used as fallback if Gemini fails (e.g. rate limits).
 
 # Google Gemini
 GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemini-2.0-flash
 
 # OpenAI-compatible endpoint (e.g. NVIDIA NIM, local LLM)
 AI_PROVIDER_ENDPOINT=https://integrate.api.nvidia.com/v1
 AI_PROVIDER_API_KEY=your-provider-api-key
-AI_MODEL=some-model-name
+AI_MODEL=meta/llama-3.3-70b-instruct
 
 # -- Public -----------------------------------------------
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/lib/__tests__/ai/client.test.ts
+++ b/lib/__tests__/ai/client.test.ts
@@ -156,28 +156,5 @@ describe('FallbackAIClient', () => {
       warnSpy.mockRestore();
       infoSpy.mockRestore();
     });
-
-    it('logs error when fallback also fails', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const primaryClient = createMockClient(undefined, new Error('503 Overloaded'));
-      const fallbackClientImpl = createMockClient(undefined, new Error('500 Server Error'));
-
-      const client = new FallbackAIClient(
-        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
-        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
-      );
-
-      await expect(client.generateContent(defaultParams)).rejects.toThrow();
-
-      expect(warnSpy).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[AI Fallback]'),
-        expect.stringContaining('Error')
-      );
-
-      warnSpy.mockRestore();
-      errorSpy.mockRestore();
-    });
   });
 });

--- a/lib/__tests__/ai/client.test.ts
+++ b/lib/__tests__/ai/client.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FallbackAIClient, AIClient, AIGenerateContentParams } from '@/lib/ai/client';
+
+const defaultParams: AIGenerateContentParams = {
+  model: 'consumer-model',
+  contents: 'Test prompt',
+  config: {
+    temperature: 0.7,
+    responseMimeType: 'application/json',
+  },
+};
+
+function createMockClient(
+  resolvedValue?: { text: string },
+  rejectedError?: Error
+): AIClient & { generateContent: ReturnType<typeof vi.fn> } {
+  if (rejectedError) {
+    return {
+      generateContent: vi.fn().mockRejectedValue(rejectedError),
+    };
+  }
+  return {
+    generateContent: vi.fn().mockResolvedValue(resolvedValue || { text: '{"ok": true}' }),
+  };
+}
+
+describe('FallbackAIClient', () => {
+  describe('single provider (no fallback)', () => {
+    it('returns result from primary when it succeeds', async () => {
+      const mockClient = createMockClient({ text: '{"result": "primary"}' });
+      const client = new FallbackAIClient({
+        client: mockClient,
+        model: 'primary-model',
+        name: 'google',
+      });
+
+      const result = await client.generateContent(defaultParams);
+      expect(result.text).toBe('{"result": "primary"}');
+    });
+
+    it('throws when primary fails and no fallback configured', async () => {
+      const mockClient = createMockClient(undefined, new Error('429 Rate limit'));
+      const client = new FallbackAIClient({
+        client: mockClient,
+        model: 'primary-model',
+        name: 'google',
+      });
+
+      await expect(client.generateContent(defaultParams)).rejects.toThrow('429 Rate limit');
+    });
+
+    it('overrides model param with provider-specific model', async () => {
+      const mockClient = createMockClient({ text: '{"ok": true}' });
+      const client = new FallbackAIClient({
+        client: mockClient,
+        model: 'gemini-2.0-flash',
+        name: 'google',
+      });
+
+      await client.generateContent(defaultParams);
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-2.0-flash' })
+      );
+    });
+  });
+
+  describe('with fallback configured', () => {
+    it('returns primary result when primary succeeds', async () => {
+      const primaryClient = createMockClient({ text: '{"result": "from-google"}' });
+      const fallbackClientImpl = createMockClient({ text: '{"result": "from-nvidia"}' });
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      const result = await client.generateContent(defaultParams);
+      expect(result.text).toBe('{"result": "from-google"}');
+      expect(fallbackClientImpl.generateContent).not.toHaveBeenCalled();
+    });
+
+    it('falls back to secondary when primary fails', async () => {
+      const primaryClient = createMockClient(undefined, new Error('429 Rate limit exceeded'));
+      const fallbackClientImpl = createMockClient({ text: '{"result": "from-nvidia"}' });
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      const result = await client.generateContent(defaultParams);
+      expect(result.text).toBe('{"result": "from-nvidia"}');
+      expect(primaryClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-2.0-flash' })
+      );
+      expect(fallbackClientImpl.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'nvidia-model' })
+      );
+    });
+
+    it('throws primary error when both providers fail', async () => {
+      const primaryClient = createMockClient(undefined, new Error('503 Service Unavailable'));
+      const fallbackClientImpl = createMockClient(
+        undefined,
+        new Error('500 Internal Server Error')
+      );
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      await expect(client.generateContent(defaultParams)).rejects.toThrow(
+        '503 Service Unavailable'
+      );
+    });
+
+    it('preserves all other params when overriding model', async () => {
+      const fallbackClientImpl = createMockClient({ text: '{"ok": true}' });
+      const primaryClient = createMockClient(undefined, new Error('fail'));
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      await client.generateContent(defaultParams);
+      expect(fallbackClientImpl.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'nvidia-model',
+          contents: defaultParams.contents,
+          config: defaultParams.config,
+        })
+      );
+    });
+
+    it('logs warning when falling back', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const primaryClient = createMockClient(undefined, new Error('429 Rate limit'));
+      const fallbackClientImpl = createMockClient({ text: '{"ok": true}' });
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      await client.generateContent(defaultParams);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[AI Fallback]'),
+        expect.stringContaining('Error')
+      );
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Successfully recovered'));
+
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
+    it('logs error when fallback also fails', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const primaryClient = createMockClient(undefined, new Error('503 Overloaded'));
+      const fallbackClientImpl = createMockClient(undefined, new Error('500 Server Error'));
+
+      const client = new FallbackAIClient(
+        { client: primaryClient, model: 'gemini-2.0-flash', name: 'google' },
+        { client: fallbackClientImpl, model: 'nvidia-model', name: 'nvidia' }
+      );
+
+      await expect(client.generateContent(defaultParams)).rejects.toThrow();
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[AI Fallback]'),
+        expect.stringContaining('Error')
+      );
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -4,7 +4,7 @@ const AI_PROVIDER_ENDPOINT = process.env.AI_PROVIDER_ENDPOINT;
 const AI_PROVIDER_API_KEY = process.env.AI_PROVIDER_API_KEY;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.0-flash';
-const NVIDIA_MODEL = process.env.AI_MODEL || 'meta/llama-3.3-70b-instruct';
+const AI_MODEL = process.env.AI_MODEL || 'meta/llama-3.3-70b-instruct';
 
 export type AIProvider = 'google' | 'nvidia';
 
@@ -74,23 +74,9 @@ export class FallbackAIClient implements AIClient {
   }
 }
 
-function isCustomProviderConfigured(): boolean {
-  return !!(AI_PROVIDER_ENDPOINT && AI_PROVIDER_API_KEY);
-}
-
-function isGeminiConfigured(): boolean {
-  return !!GEMINI_API_KEY;
-}
-
-export function getAIProvider(): AIProvider {
-  if (isCustomProviderConfigured()) return 'nvidia';
-  if (isGeminiConfigured()) return 'google';
-  throw new Error('No api keys provided!');
-}
-
 export function createAIClient(): AIClient {
-  const nvidiaConfigured = isCustomProviderConfigured();
-  const geminiConfigured = isGeminiConfigured();
+  const nvidiaConfigured = !!(AI_PROVIDER_ENDPOINT && AI_PROVIDER_API_KEY);
+  const geminiConfigured = !!GEMINI_API_KEY;
 
   if (nvidiaConfigured && geminiConfigured) {
     // Both configured: Gemini primary, Nvidia fallback
@@ -104,7 +90,7 @@ export function createAIClient(): AIClient {
         apiKey: AI_PROVIDER_API_KEY!,
         baseURL: AI_PROVIDER_ENDPOINT!,
       }),
-      model: NVIDIA_MODEL,
+      model: AI_MODEL,
       name: 'nvidia',
     };
     return new FallbackAIClient(primary, fallback);
@@ -124,7 +110,7 @@ export function createAIClient(): AIClient {
         apiKey: AI_PROVIDER_API_KEY!,
         baseURL: AI_PROVIDER_ENDPOINT!,
       }),
-      model: NVIDIA_MODEL,
+      model: AI_MODEL,
       name: 'nvidia',
     });
   }

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -1,10 +1,12 @@
-import { createGoogleClient, createNvidiaClient } from "./client-generators";
+import { createGoogleClient, createNvidiaClient } from './client-generators';
 
 const AI_PROVIDER_ENDPOINT = process.env.AI_PROVIDER_ENDPOINT;
 const AI_PROVIDER_API_KEY = process.env.AI_PROVIDER_API_KEY;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.0-flash';
+const NVIDIA_MODEL = process.env.AI_MODEL || 'meta/llama-3.3-70b-instruct';
 
-export type AIProvider = "google" | "nvidia";
+export type AIProvider = 'google' | 'nvidia';
 
 export interface AIGenerateContentParams {
   model: string;
@@ -22,25 +24,110 @@ export interface AIClient {
   generateContent(params: AIGenerateContentParams): Promise<{ text: string }>;
 }
 
+interface ProviderConfig {
+  client: AIClient;
+  model: string;
+  name: AIProvider;
+}
+
+export class FallbackAIClient implements AIClient {
+  private primary: ProviderConfig;
+  private fallback?: ProviderConfig;
+
+  constructor(primary: ProviderConfig, fallback?: ProviderConfig) {
+    this.primary = primary;
+    this.fallback = fallback;
+  }
+
+  async generateContent(params: AIGenerateContentParams): Promise<{ text: string }> {
+    try {
+      const result = await this.primary.client.generateContent({
+        ...params,
+        model: this.primary.model,
+      });
+      return result;
+    } catch (primaryError) {
+      if (!this.fallback) {
+        throw primaryError;
+      }
+
+      console.warn(
+        `[AI Fallback] Primary provider "${this.primary.name}" failed, falling back to "${this.fallback.name}".`,
+        `Error: ${primaryError instanceof Error ? primaryError.message : String(primaryError)}`
+      );
+
+      try {
+        const result = await this.fallback.client.generateContent({
+          ...params,
+          model: this.fallback.model,
+        });
+        console.info(`[AI Fallback] Successfully recovered using "${this.fallback.name}".`);
+        return result;
+      } catch (fallbackError) {
+        console.error(
+          `[AI Fallback] Fallback provider "${this.fallback.name}" also failed.`,
+          `Error: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
+        );
+        throw primaryError;
+      }
+    }
+  }
+}
+
 function isCustomProviderConfigured(): boolean {
   return !!(AI_PROVIDER_ENDPOINT && AI_PROVIDER_API_KEY);
 }
 
+function isGeminiConfigured(): boolean {
+  return !!GEMINI_API_KEY;
+}
+
 export function getAIProvider(): AIProvider {
-  return isCustomProviderConfigured() ? "nvidia" : "google";
+  if (isCustomProviderConfigured()) return 'nvidia';
+  if (isGeminiConfigured()) return 'google';
+  throw new Error('No api keys provided!');
 }
 
 export function createAIClient(): AIClient {
-  if (isCustomProviderConfigured()) {
-    return createNvidiaClient({
-      apiKey: AI_PROVIDER_API_KEY!,
-      baseURL: AI_PROVIDER_ENDPOINT!,
+  const nvidiaConfigured = isCustomProviderConfigured();
+  const geminiConfigured = isGeminiConfigured();
+
+  if (nvidiaConfigured && geminiConfigured) {
+    // Both configured: Gemini primary, Nvidia fallback
+    const primary: ProviderConfig = {
+      client: createGoogleClient(GEMINI_API_KEY!),
+      model: GEMINI_MODEL,
+      name: 'google',
+    };
+    const fallback: ProviderConfig = {
+      client: createNvidiaClient({
+        apiKey: AI_PROVIDER_API_KEY!,
+        baseURL: AI_PROVIDER_ENDPOINT!,
+      }),
+      model: NVIDIA_MODEL,
+      name: 'nvidia',
+    };
+    return new FallbackAIClient(primary, fallback);
+  }
+
+  if (geminiConfigured) {
+    return new FallbackAIClient({
+      client: createGoogleClient(GEMINI_API_KEY!),
+      model: GEMINI_MODEL,
+      name: 'google',
     });
   }
 
-  if (GEMINI_API_KEY) {
-    return createGoogleClient(GEMINI_API_KEY);
+  if (nvidiaConfigured) {
+    return new FallbackAIClient({
+      client: createNvidiaClient({
+        apiKey: AI_PROVIDER_API_KEY!,
+        baseURL: AI_PROVIDER_ENDPOINT!,
+      }),
+      model: NVIDIA_MODEL,
+      name: 'nvidia',
+    });
   }
 
-  throw new Error("No api keys provided!");
+  throw new Error('No api keys provided!');
 }

--- a/lib/ai/generate-quiz.ts
+++ b/lib/ai/generate-quiz.ts
@@ -3,7 +3,7 @@ import { Language, Word } from '@/types/Words';
 import { QUIZ_PROMPTS } from './quiz-prompts';
 import { createAIClient } from './client';
 
-const MODEL_NAME = process.env.AI_MODEL || 'gemini-2.5-flash';
+const MODEL_NAME = process.env.AI_MODEL || 'gemini-2.0-flash';
 
 function stripWordForPrompt(word: Word): Pick<Word, '_id' | 'word' | 'definition'> {
   return {
@@ -14,11 +14,11 @@ function stripWordForPrompt(word: Word): Pick<Word, '_id' | 'word' | 'definition
 }
 
 export async function generateQuizWithWords(
-	words: Word[],
-	level: number,
-	learningLanguage: Language,
-	userLanguage: Language,
-	quizCount: number = 1
+  words: Word[],
+  level: number,
+  learningLanguage: Language,
+  userLanguage: Language,
+  quizCount: number = 1
 ): Promise<QuizGeneratorResponse> {
   try {
     if (!words || words.length < 3) {
@@ -36,16 +36,16 @@ export async function generateQuizWithWords(
       throw new Error(`Unsupported user language: ${userLanguage}`);
     }
 
-	const systemPrompt = promptConfig.systemPrompt(userLanguage, learningLanguage, quizCount);
-	const strippedWords = words.map(stripWordForPrompt);
-	const userPrompt = promptConfig.userPrompt(
-		strippedWords,
-		level,
-		learningLanguage,
-		userLanguage,
-		quizCount
-	);
-	const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
+    const systemPrompt = promptConfig.systemPrompt(userLanguage, learningLanguage, quizCount);
+    const strippedWords = words.map(stripWordForPrompt);
+    const userPrompt = promptConfig.userPrompt(
+      strippedWords,
+      level,
+      learningLanguage,
+      userLanguage,
+      quizCount
+    );
+    const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
 
     const result = await client.generateContent({
       model: MODEL_NAME,

--- a/lib/ai/generate-words.ts
+++ b/lib/ai/generate-words.ts
@@ -1,66 +1,72 @@
-import { Language, Word, WordsGeneratorResponse } from "@/types/Words";
-import { WORDS_PROMPTS } from "./words-prompts";
-import { createAIClient } from "./client";
+import { Language, Word, WordsGeneratorResponse } from '@/types/Words';
+import { WORDS_PROMPTS } from './words-prompts';
+import { createAIClient } from './client';
 
-const MODEL_NAME = process.env.AI_MODEL || "gemini-2.5-flash";
+const MODEL_NAME = process.env.AI_MODEL || 'gemini-2.0-flash';
 
 export async function generateWords(
-	words: Word[],
-	level: number,
-	learningLanguage: Language,
-	userLanguage: Language,
+  words: Word[],
+  level: number,
+  learningLanguage: Language,
+  userLanguage: Language
 ): Promise<WordsGeneratorResponse> {
-	try {
-		if (level < 1 || level > 100) {
-			throw new Error("Level must be between 1 and 100");
-		}
+  try {
+    if (level < 1 || level > 100) {
+      throw new Error('Level must be between 1 and 100');
+    }
 
-		const client = createAIClient();
+    const client = createAIClient();
 
-		const promptConfig = WORDS_PROMPTS[userLanguage];
-		if (!promptConfig) {
-			throw new Error(`Unsupported user language: ${userLanguage}`);
-		}
+    const promptConfig = WORDS_PROMPTS[userLanguage];
+    if (!promptConfig) {
+      throw new Error(`Unsupported user language: ${userLanguage}`);
+    }
 
-		const systemPrompt = promptConfig.systemPrompt();
-		const userPrompt = promptConfig.userPrompt(words, level, learningLanguage, userLanguage);
-		const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
+    const systemPrompt = promptConfig.systemPrompt();
+    const userPrompt = promptConfig.userPrompt(words, level, learningLanguage, userLanguage);
+    const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
 
-		// TODO: Separate the response_format and add it to the options here
-		const result = await client.generateContent({
-			model: MODEL_NAME,
-			contents: fullPrompt,
-			config: {
-				temperature: 0.7,
-				topK: 40,
-				topP: 0.9,
-				responseMimeType: "application/json",
-			},
-		});
+    // TODO: Separate the response_format and add it to the options here
+    const result = await client.generateContent({
+      model: MODEL_NAME,
+      contents: fullPrompt,
+      config: {
+        temperature: 0.7,
+        topK: 40,
+        topP: 0.9,
+        responseMimeType: 'application/json',
+      },
+    });
 
-		const responseText = result.text;
+    const responseText = result.text;
 
-		try {
-			const parsedResponse = JSON.parse(responseText) as WordsGeneratorResponse;
+    try {
+      const parsedResponse = JSON.parse(responseText) as WordsGeneratorResponse;
 
-			if (!parsedResponse.words || !Array.isArray(parsedResponse.words)) {
-				throw new Error("Response missing words array");
-			}
+      if (!parsedResponse.words || !Array.isArray(parsedResponse.words)) {
+        throw new Error('Response missing words array');
+      }
 
-			parsedResponse.words.forEach((word, index) => {
-				if (!word.definition || !word.language || !word.phoneticNotation) {
-					throw new Error(`Word ${index + 1} missing required fields (definition, language, phoneticNotation)`);
-				}
-			});
+      parsedResponse.words.forEach((word, index) => {
+        if (!word.definition || !word.language || !word.phoneticNotation) {
+          throw new Error(
+            `Word ${index + 1} missing required fields (definition, language, phoneticNotation)`
+          );
+        }
+      });
 
-			return parsedResponse;
-		} catch (parseError) {
-			console.error("Failed to parse JSON response:", parseError);
-			console.error("Response text:", responseText);
-			throw new Error(`Failed to parse words response: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
-		}
-	} catch (error) {
-		console.error("Error generating words:", error);
-		throw new Error(`Failed to generate words: ${error instanceof Error ? error.message : String(error)}`);
-	}
+      return parsedResponse;
+    } catch (parseError) {
+      console.error('Failed to parse JSON response:', parseError);
+      console.error('Response text:', responseText);
+      throw new Error(
+        `Failed to parse words response: ${parseError instanceof Error ? parseError.message : String(parseError)}`
+      );
+    }
+  } catch (error) {
+    console.error('Error generating words:', error);
+    throw new Error(
+      `Failed to generate words: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }


### PR DESCRIPTION
- Introduce FallbackAIClient that wraps both providers
- When both Gemini and Nvidia keys are configured, Gemini is primary and Nvidia is used as fallback on failure (e.g. 429 rate limits)
- FallbackAIClient overrides model param with provider-specific model
- Add GEMINI_MODEL env var for separate model configuration
- Log warnings when fallback triggers for monitoring
- Add comprehensive unit tests for FallbackAIClient
- Update .env.example with new env vars and fallback docs