### PR TITLE
feat: add error-driven requiz with reverse direction (L1->L2)

### DIFF
--- a/components/Quiz/QuizFinished.tsx
+++ b/components/Quiz/QuizFinished.tsx
@@ -1,18 +1,24 @@
-import { useConfetti } from "@/hooks/useConfetti";
-import { useTranslations } from "next-intl";
-import { useEffect } from "react";
-import { motion, AnimatePresence, easeOut, easeIn } from "framer-motion";
-import { useRouter } from "@/src/i18n/navigation";
+import { useConfetti } from '@/hooks/useConfetti';
+import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
+import { motion, AnimatePresence, easeOut, easeIn } from 'framer-motion';
+import { useRouter } from '@/src/i18n/navigation';
+
+interface RequizSummary {
+  total: number;
+  correct: number;
+}
 
 interface Props {
   isSuccess: boolean;
   successPoints: { errors: number; success: number };
   onRestartQuiz?: () => void;
+  requizSummary?: RequizSummary;
 }
 
-const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
+const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz, requizSummary }: Props) => {
   const { triggerFireworks, triggerSchoolPride, resetConfetti } = useConfetti();
-  const t = useTranslations("quiz-finished");
+  const t = useTranslations('quiz-finished');
   const router = useRouter();
 
   const totalQuestions = successPoints.success + successPoints.errors;
@@ -37,65 +43,89 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
   };
 
   const onGoToCards = () => {
-    router.push("/cards");
+    router.push('/cards');
   };
 
+  const hasRequiz = requizSummary && requizSummary.total > 0;
+
   return (
-    // Use theme-bg-light and theme-bg-dark for the background
     <div className="flex items-center w-full md:-my-10 justify-center bg-theme-bg-light dark:bg-theme-bg-dark relative overflow-hidden">
       <AnimatePresence mode="wait">
         {isSuccess ? (
           <motion.div
             key="success-card"
-            // Use theme-fg-light/dark for card background and theme-text-light/dark for general text
             className="rounded-3xl p-6 md:p-8 text-center max-w-md w-full relative transform transition-all duration-500 hover:scale-101
-                       bg-theme-fg-light text-theme-text-light
-                       dark:bg-theme-fg-dark dark:text-theme-text-dark"
+ bg-theme-fg-light text-theme-text-light
+ dark:bg-theme-fg-dark dark:text-theme-text-dark"
             variants={cardVariants}
             initial="hidden"
             animate="visible"
             exit="exit"
           >
-            <h1 className="text-3xl font-extrabold text-secondary mb-4 drop-shadow-lg animate-bounce-short">{t("congratulations")}!</h1>
-            <p className="text-xl  font-semibold mb-6 leading-tight">
-              {t("you-answered-correctly", { count: successPoints.success, total: totalQuestions })}
+            <h1 className="text-3xl font-extrabold text-secondary mb-4 drop-shadow-lg animate-bounce-short">
+              {t('congratulations')}!
+            </h1>
+            <p className="text-xl font-semibold mb-6 leading-tight">
+              {t('you-answered-correctly', { count: successPoints.success, total: totalQuestions })}
             </p>
             <div className="w-24 h-24 mx-auto mb-6 bg-secondary/20 rounded-full flex items-center justify-center shadow-inner">
-              <span className="text-2xl font-bold text-secondary">{Math.round(percentageCorrect)}%</span>
+              <span className="text-2xl font-bold text-secondary">
+                {Math.round(percentageCorrect)}%
+              </span>
             </div>
-            <p className="text-lg mb-8">{t("fantastic-job-keep-it-up")}</p>
+            {hasRequiz && (
+              <p className="text-sm mb-4 text-amber-600 dark:text-amber-400">
+                {t('requiz-summary', {
+                  correct: requizSummary!.correct,
+                  total: requizSummary!.total,
+                })}
+              </p>
+            )}
+            <p className="text-lg mb-8">{t('fantastic-job-keep-it-up')}</p>
             <button
               onClick={onGoToCards}
               className="bg-secondary cursor-pointer hover:brightness-110 text-theme-text-dark font-bold py-3 px-8 rounded-full transition duration-300 ease-in-out transform hover:-translate-y-1 hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-secondary/50"
             >
-              {t("go-cards")}
+              {t('go-cards')}
             </button>
           </motion.div>
         ) : (
           <motion.div
             key="failure-card"
             className="rounded-3xl p-6 md:p-8 text-center max-w-md w-full relative transform transition-all duration-500 hover:scale-101
-                       bg-theme-fg-light text-theme-text-light
-                       dark:bg-theme-fg-dark dark:text-theme-text-dark"
+ bg-theme-fg-light text-theme-text-light
+ dark:bg-theme-fg-dark dark:text-theme-text-dark"
             variants={cardVariants}
             initial="hidden"
             animate="visible"
             exit="exit"
           >
-            <h1 className="text-3xl font-extrabold text-error mb-4 drop-shadow-lg">{t("better-luck-next-time")}</h1>
+            <h1 className="text-3xl font-extrabold text-error mb-4 drop-shadow-lg">
+              {t('better-luck-next-time')}
+            </h1>
             <p className="text-xl font-semibold mb-6 leading-tight">
-              {t("you-answered-correctly", { count: successPoints.success, total: totalQuestions })}
+              {t('you-answered-correctly', { count: successPoints.success, total: totalQuestions })}
             </p>
             <div className="w-24 h-24 mx-auto mb-6 bg-error/20 rounded-full flex items-center justify-center shadow-inner">
-              <span className="text-2xl font-bold text-error">{Math.round(percentageCorrect)}%</span>
+              <span className="text-2xl font-bold text-error">
+                {Math.round(percentageCorrect)}%
+              </span>
             </div>
-            <p className="text-lg mb-8">{t("dont-give-up-try-again")}</p>
+            {hasRequiz && (
+              <p className="text-sm mb-4 text-amber-600 dark:text-amber-400">
+                {t('requiz-summary', {
+                  correct: requizSummary!.correct,
+                  total: requizSummary!.total,
+                })}
+              </p>
+            )}
+            <p className="text-lg mb-8">{t('dont-give-up-try-again')}</p>
             {onRestartQuiz && (
               <button
                 onClick={onRestartQuiz}
                 className="bg-error cursor-pointer hover:brightness-110 text-theme-text-dark font-bold py-3 px-8 rounded-full transition duration-300 ease-in-out transform hover:-translate-y-1 hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-error/50"
               >
-                {t("try-again")}
+                {t('try-again')}
               </button>
             )}
           </motion.div>

--- a/components/Quiz/RequizView.tsx
+++ b/components/Quiz/RequizView.tsx
@@ -1,0 +1,94 @@
+import { useTranslations } from 'next-intl';
+import { RequizQuestion, RequizOption } from '@/lib/requiz';
+
+interface Props {
+  question: RequizQuestion;
+  onAnswerClick: (option: RequizOption) => void;
+  feedback: { correct: string; wrong: string };
+  onContinue: () => void;
+  progress: { current: number; total: number };
+}
+
+const RequizView = ({ question, onAnswerClick, feedback, onContinue, progress }: Props) => {
+  const t = useTranslations('requiz');
+
+  if (!question) return null;
+
+  const hasAnswered = feedback.correct !== '' || feedback.wrong !== '';
+
+  return (
+    <div className="flex flex-col gap-5 w-full max-w-md" aria-live="polite">
+      {/* Requiz header */}
+      <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
+        <span className="inline-flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-amber-500" />
+          {t('review-missed-words')}
+        </span>
+      </div>
+
+      {/* Question stem: definition in native language */}
+      <p className="text-xl">{t('which-word-means', { definition: question.stem })}</p>
+
+      {/* Answer options: target-language words */}
+      <ul className="flex w-full flex-col gap-5">
+        {question.options.map(option => (
+          <li
+            key={option.word}
+            onClick={() => !hasAnswered && onAnswerClick(option)}
+            onKeyDown={e =>
+              !hasAnswered && (e.key === 'Enter' || e.key === ' ') && onAnswerClick(option)
+            }
+            role="button"
+            tabIndex={hasAnswered ? -1 : 0}
+            className={`cursor-pointer flex flex-col items-start list-none py-2 px-5 rounded-md transition-colors
+ dark:bg-theme-fg-dark bg-theme-fg-light
+ ${!hasAnswered ? 'hover:bg-secondary' : ''}
+ ${feedback.correct === option.word ? 'blink-success' : ''}
+ ${feedback.wrong === option.word ? 'blink-error' : ''}
+ ${hasAnswered ? 'pointer-events-none' : ''}`}
+          >
+            <span className="font-medium">{option.word}</span>
+            <span className="text-xs font-extralight italic opacity-70">
+              {option.phoneticNotation}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* Feedback panel */}
+      {hasAnswered && (
+        <div
+          className={`py-3 px-4 rounded-lg border-l-4 text-sm leading-relaxed ${
+            feedback.correct
+              ? 'bg-green-50 dark:bg-green-900/20 border-green-400 dark:border-green-600 text-green-800 dark:text-green-200'
+              : 'bg-red-50 dark:bg-red-900/20 border-red-400 dark:border-red-600 text-red-800 dark:text-red-200'
+          }`}
+        >
+          <p className="font-semibold mb-1">{feedback.correct ? t('correct') : t('incorrect')}</p>
+          <p>
+            {feedback.correct
+              ? t('correct-answer-was', { word: question.correctWord })
+              : t('correct-answer-is', { word: question.correctWord })}
+          </p>
+        </div>
+      )}
+
+      {/* Continue button */}
+      {hasAnswered && (
+        <button
+          onClick={onContinue}
+          className="w-full py-2 px-4 rounded-md font-medium transition-colors bg-primary bg-info cursor-pointer hover:bg-info/80 text-white hover:bg-primary/90 active:bg-primary/80"
+        >
+          {progress.current < progress.total ? t('continue') : t('finish-review')}
+        </button>
+      )}
+
+      {/* Progress */}
+      <p className="text-[0.6rem] italic font-extralight opacity-60">
+        {t('question', { current: progress.current, total: progress.total })}
+      </p>
+    </div>
+  );
+};
+
+export default RequizView;

--- a/hooks/useQuizManager.tsx
+++ b/hooks/useQuizManager.tsx
@@ -6,6 +6,7 @@ import useLocalStorage from '@/hooks/useLocalStorage';
 import { processAnswer } from '@/lib/correctionWords';
 import { getWordsByIds, updateWordsData, updateUserData } from '@/lib/apis';
 import { saveQuizSession } from '@/lib/apis';
+import { buildRequizQuestions, RequizOption } from '@/lib/requiz';
 import { Quiz, QuizAnswer } from '@/types/Quiz';
 import { User, Word } from '@/types/Words';
 
@@ -43,6 +44,19 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
   const [isFinishing, setIsFinishing] = useState(false);
   const [startingTimer, setStartingTimer] = useState<number>();
 
+  // Requiz state
+  const [missedWordIds, setMissedWordIds] = useState<string[]>([]);
+  const [requizQuestions, setRequizQuestions] = useState<ReturnType<typeof buildRequizQuestions>>(
+    []
+  );
+  const [requizStep, setRequizStep] = useState(0);
+  const [requizScore, setRequizScore] = useState({ correct: 0, wrong: 0 });
+  const [isRequizPhase, setIsRequizPhase] = useState(false);
+  const [requizFeedback, setRequizFeedback] = useState<{ correct: string; wrong: string }>({
+    correct: '',
+    wrong: '',
+  });
+
   const originalEaseFactors = useRef<Map<string, number>>(new Map());
   const quizStartTime = useRef(Date.now());
   const isFinishingRef = useRef(false);
@@ -53,6 +67,10 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     totalExpectedQuizzes > 0 &&
     quizStep >= displayQuiz.length &&
     displayQuiz.length > 0;
+
+  // True when main quiz is complete (all quizzes answered)
+  const isMainQuizComplete =
+    displayQuiz.length > 0 && quizStep >= displayQuiz.length && isAllQuizzesReady && !isRequizPhase;
 
   useEffect(() => {
     const start = Date.now();
@@ -111,63 +129,83 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     isGeneratingMore,
   ]);
 
-  // Effect to handle the end of the quiz
+  // Build requiz questions when main quiz completes with missed words
+  useEffect(() => {
+    if (isQuizFinished || isRequizPhase) return;
+    if (!isMainQuizComplete) return;
+    if (missedWordIds.length === 0) return;
+    if (usedWords.length === 0) return;
+
+    const questions = buildRequizQuestions(missedWordIds, usedWords);
+    if (questions.length > 0) {
+      setRequizQuestions(questions);
+      setRequizStep(0);
+      setRequizScore({ correct: 0, wrong: 0 });
+      setRequizFeedback({ correct: '', wrong: '' });
+      setIsRequizPhase(true);
+    }
+  }, [isMainQuizComplete, missedWordIds, usedWords, isQuizFinished, isRequizPhase]);
+
+  // Effect to handle the end of the quiz (after requiz if applicable)
   // Quiz only truly finishes when ALL quizzes are ready AND the user has answered all of them
   useEffect(() => {
     if (isQuizFinished || !session) return;
     if (isFinishingRef.current) return;
 
-    if (displayQuiz.length && quizStep >= displayQuiz.length && userData && isAllQuizzesReady) {
-      isFinishingRef.current = true;
-      setIsFinishing(true);
+    // Only finish when main quiz is complete AND (requiz is done OR no missed words)
+    const requizDone = isRequizPhase ? requizStep >= requizQuestions.length : true;
+    const mainDone = displayQuiz.length && quizStep >= displayQuiz.length && isAllQuizzesReady;
+    if (!mainDone || !requizDone || !userData) return;
 
-      const actualTimeEnd = Date.now();
-      const updatedUserData: User = JSON.parse(JSON.stringify(userData));
-      const isSucceed = score.success / 2 > score.errors;
-      const learningProgress = updatedUserData?.learningProgress.find(
-        lp => lp.language === displayQuiz[0].language
-      );
+    isFinishingRef.current = true;
+    setIsFinishing(true);
 
-      updateWordsData(usedWords)
-        .then(() => {
-          if (!learningProgress) throw new Error('Learning progress not found');
-          learningProgress.level = isSucceed
-            ? learningProgress.level + 1
-            : learningProgress.level > 0
-              ? learningProgress.level - 1
-              : 0;
-          learningProgress.wordsMastered += usedWords.filter(word => word.repetitions > 0).length;
-          learningProgress.currentStreak = isSucceed ? learningProgress.currentStreak + 1 : 0;
-          learningProgress.lastSessionDate = new Date();
-          if (!startingTimer) throw new Error('Starting timer not found');
-          learningProgress.timeSpent += Math.round(actualTimeEnd - startingTimer);
+    const actualTimeEnd = Date.now();
+    const updatedUserData: User = JSON.parse(JSON.stringify(userData));
+    const isSucceed = score.success / 2 > score.errors;
+    const learningProgress = updatedUserData?.learningProgress.find(
+      lp => lp.language === displayQuiz[0].language
+    );
 
-          const wordsMasteredCount = usedWords.filter(word => word.repetitions > 0).length;
-          saveQuizSession({
-            language: displayQuiz[0].language,
-            totalQuestions: score.success + score.errors,
-            correctAnswers: score.success,
-            wordsMastered: wordsMasteredCount,
-            duration: actualTimeEnd - quizStartTime.current,
-          }).catch(err => console.error('Error saving quiz session:', err));
+    updateWordsData(usedWords)
+      .then(() => {
+        if (!learningProgress) throw new Error('Learning progress not found');
+        learningProgress.level = isSucceed
+          ? learningProgress.level + 1
+          : learningProgress.level > 0
+            ? learningProgress.level - 1
+            : 0;
+        learningProgress.wordsMastered += usedWords.filter(word => word.repetitions > 0).length;
+        learningProgress.currentStreak = isSucceed ? learningProgress.currentStreak + 1 : 0;
+        learningProgress.lastSessionDate = new Date();
+        if (!startingTimer) throw new Error('Starting timer not found');
+        learningProgress.timeSpent += Math.round(actualTimeEnd - startingTimer);
 
-          return updateUserData(updatedUserData);
-        })
-        .then(() => {
-          setIsQuizFinished(true);
-          if (isSucceed) {
-            handleDeleteQuiz();
-          }
-        })
-        .catch(error => {
-          console.error('Error finishing quiz:', error);
-          setIsQuizFinished(true);
-        })
-        .finally(() => {
-          isFinishingRef.current = false;
-          setIsFinishing(false);
-        });
-    }
+        const wordsMasteredCount = usedWords.filter(word => word.repetitions > 0).length;
+        saveQuizSession({
+          language: displayQuiz[0].language,
+          totalQuestions: score.success + score.errors,
+          correctAnswers: score.success,
+          wordsMastered: wordsMasteredCount,
+          duration: actualTimeEnd - quizStartTime.current,
+        }).catch(err => console.error('Error saving quiz session:', err));
+
+        return updateUserData(updatedUserData);
+      })
+      .then(() => {
+        setIsQuizFinished(true);
+        if (isSucceed) {
+          handleDeleteQuiz();
+        }
+      })
+      .catch(error => {
+        console.error('Error finishing quiz:', error);
+        setIsQuizFinished(true);
+      })
+      .finally(() => {
+        isFinishingRef.current = false;
+        setIsFinishing(false);
+      });
   }, [
     quizStep,
     displayQuiz,
@@ -179,6 +217,9 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     deleteValue,
     isQuizFinished,
     isAllQuizzesReady,
+    isRequizPhase,
+    requizStep,
+    requizQuestions.length,
   ]);
 
   const handleAnswerClick = useCallback(
@@ -195,6 +236,12 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
       } else {
         setScore(prev => ({ ...prev, errors: prev.errors + 1 }));
         setFeedback({ correct: '', wrong: option.answer });
+
+        // Track missed word IDs for requiz
+        setMissedWordIds(prev => {
+          const newIds = currentQuestion.usedWords.filter(id => !prev.includes(id));
+          return [...prev, ...newIds];
+        });
       }
 
       setUsedWords(prev => {
@@ -249,6 +296,43 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     }
   }, [displayQuiz, quizStep, questionStep]);
 
+  // Requiz answer handler
+  const handleRequizAnswerClick = useCallback(
+    (option: RequizOption) => {
+      if (requizStep >= requizQuestions.length) return;
+
+      const currentRequiz = requizQuestions[requizStep];
+
+      if (option.isCorrect) {
+        setRequizScore(prev => ({ ...prev, correct: prev.correct + 1 }));
+        setRequizFeedback({ correct: option.word, wrong: '' });
+      } else {
+        setRequizScore(prev => ({ ...prev, wrong: prev.wrong + 1 }));
+        setRequizFeedback({ correct: '', wrong: option.word });
+      }
+
+      // Update SRS for the requiz word
+      setUsedWords(prev => {
+        const wordMap = new Map(prev.map(w => [w._id!, w]));
+        for (const wordId of currentRequiz.usedWords) {
+          const word = wordMap.get(wordId);
+          if (!word) continue;
+          const originalEase = originalEaseFactors.current.get(wordId);
+          const updatedWord = processAnswer(word, option.isCorrect, originalEase);
+          wordMap.set(wordId, updatedWord);
+        }
+        return Array.from(wordMap.values());
+      });
+    },
+    [requizStep, requizQuestions]
+  );
+
+  // Requiz continue handler
+  const handleRequizContinue = useCallback(() => {
+    setRequizFeedback({ correct: '', wrong: '' });
+    setRequizStep(prev => prev + 1);
+  }, []);
+
   const restartQuiz = () => {
     setQuizStep(0);
     setQuestionStep(0);
@@ -256,6 +340,12 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     setIsFinishing(false);
     isFinishingRef.current = false;
     setScore({ errors: 0, success: 0 });
+    setMissedWordIds([]);
+    setRequizQuestions([]);
+    setRequizStep(0);
+    setRequizScore({ correct: 0, wrong: 0 });
+    setIsRequizPhase(false);
+    setRequizFeedback({ correct: '', wrong: '' });
 
     const allWordIds = [
       ...new Set(displayQuiz.flatMap(q => q.questions.flatMap(question => question.usedWords))),
@@ -284,6 +374,7 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
 
   const currentQuizItem = displayQuiz[quizStep];
   const currentQuestion = currentQuizItem?.questions[questionStep];
+  const currentRequizQuestion = isRequizPhase ? requizQuestions[requizStep] : null;
 
   return {
     isLoading: isLoading || isGeneratingQuiz,
@@ -303,5 +394,16 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     handleContinue,
     restartQuiz,
     handleDeleteQuiz,
+    // Requiz
+    isRequizPhase,
+    requizQuestions,
+    currentRequizQuestion,
+    requizStep,
+    requizScore,
+    requizFeedback,
+    requizProgress: { current: requizStep + 1, total: requizQuestions.length },
+    handleRequizAnswerClick,
+    handleRequizContinue,
+    missedWordIds,
   };
 };

--- a/lib/__tests__/requiz.test.ts
+++ b/lib/__tests__/requiz.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequizQuestions } from '../requiz';
+import { Word } from '@/types/Words';
+
+const makeWord = (id: string, word: string, definition: string, phonetic?: string): Word => ({
+  _id: id,
+  userId: 'u1',
+  word,
+  definition,
+  phoneticNotation: phonetic || word,
+  language: 'Español',
+  tags: [],
+  lastReviewed: null,
+  nextReview: new Date().toISOString(),
+  interval: 0,
+  repetitions: 0,
+  easeFactor: 2.5,
+});
+
+describe('buildRequizQuestions', () => {
+  const allWords = [
+    makeWord('w1', 'gato', 'cat', 'gato'),
+    makeWord('w2', 'perro', 'dog', 'pero'),
+    makeWord('w3', 'pájaro', 'bird', 'paharo'),
+    makeWord('w4', 'pez', 'fish', 'pes'),
+  ];
+
+  it('returns empty array when no missed word IDs', () => {
+    const result = buildRequizQuestions([], allWords);
+    expect(result).toEqual([]);
+  });
+
+  it('creates one question per missed word', () => {
+    const result = buildRequizQuestions(['w1', 'w2'], allWords);
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses definition as stem', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    expect(result[0].stem).toBe('cat');
+  });
+
+  it('sets correctWord to the target-language word', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    expect(result[0].correctWord).toBe('gato');
+  });
+
+  it('sets correctPhonetic from the word', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    expect(result[0].correctPhonetic).toBe('gato');
+  });
+
+  it('includes correct option in options array', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    const correctOpt = result[0].options.find(o => o.isCorrect);
+    expect(correctOpt).toBeDefined();
+    expect(correctOpt!.word).toBe('gato');
+    expect(correctOpt!.phoneticNotation).toBe('gato');
+  });
+
+  it('includes distractors from other words in the pool', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    const distractors = result[0].options.filter(o => !o.isCorrect);
+    expect(distractors.length).toBeLessThanOrEqual(3);
+    expect(distractors.length).toBeGreaterThanOrEqual(1);
+    distractors.forEach(d => {
+      expect(d.word).not.toBe('gato');
+      expect(d.isCorrect).toBe(false);
+    });
+  });
+
+  it('tracks usedWords with the missed word ID', () => {
+    const result = buildRequizQuestions(['w1'], allWords);
+    expect(result[0].usedWords).toEqual(['w1']);
+  });
+
+  it('handles single word in pool (no distractors available)', () => {
+    const singleWord = [makeWord('w1', 'gato', 'cat')];
+    const result = buildRequizQuestions(['w1'], singleWord);
+    expect(result).toHaveLength(1);
+    expect(result[0].options).toHaveLength(1);
+    expect(result[0].options[0].isCorrect).toBe(true);
+  });
+
+  it('shuffles options so correct answer is not always first', () => {
+    const results = Array.from({ length: 20 }, () => buildRequizQuestions(['w1'], allWords));
+    const positions = results.map(r => r[0].options.findIndex(o => o.isCorrect));
+    const uniquePositions = new Set(positions);
+    expect(uniquePositions.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles multiple missed words', () => {
+    const result = buildRequizQuestions(['w1', 'w2', 'w3'], allWords);
+    expect(result).toHaveLength(3);
+    const stems = result.map(q => q.stem);
+    expect(stems).toContain('cat');
+    expect(stems).toContain('dog');
+    expect(stems).toContain('bird');
+  });
+});

--- a/lib/requiz.ts
+++ b/lib/requiz.ts
@@ -1,0 +1,93 @@
+import { Word } from '@/types/Words';
+
+/**
+ * A requiz question built entirely from existing Word data — no LLM needed.
+ * Uses the "Reverse Direction" approach: the stem is the word's definition
+ * (in the user's native language), and options are target-language words.
+ * This shifts the cognitive task from recognition (L2→L1) to productive
+ * recall (L1→L2), which is a harder and more effective encoding operation.
+ *
+ * Approach 1 (Option Shuffle) is baked in: distractors are drawn from the
+ * full session word pool, not the original question, destroying positional cues.
+ */
+export interface RequizQuestion {
+  /** The definition of the target word, used as the question stem */
+  stem: string;
+  /** The correct target-language word */
+  correctWord: string;
+  /** Phonetic notation for the correct word */
+  correctPhonetic: string;
+  /** All options (including correct), already shuffled */
+  options: RequizOption[];
+  /** Word IDs this requiz question targets */
+  usedWords: string[];
+}
+
+export interface RequizOption {
+  word: string;
+  phoneticNotation: string;
+  isCorrect: boolean;
+}
+
+/**
+ * Shuffles an array using Fisher-Yates algorithm.
+ */
+function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = result[i];
+    result[i] = result[j];
+    result[j] = temp;
+  }
+  return result;
+}
+
+/**
+ * Builds reverse-direction requiz questions for missed words.
+ *
+ * For each missed word:
+ * - Stem = word's definition (native language)
+ * - Correct option = the target-language word + its phonetic notation
+ * - Distractors = other words from the same quiz session (shuffled)
+ *
+ * @param missedWordIds - IDs of words the user answered incorrectly
+ * @param allWords - All Word objects used in the quiz session
+ * @returns RequizQuestion array (one per missed word), shuffled
+ */
+export function buildRequizQuestions(missedWordIds: string[], allWords: Word[]): RequizQuestion[] {
+  if (missedWordIds.length === 0) return [];
+
+  const missedWords = allWords.filter(w => missedWordIds.includes(w._id!));
+  const distractorPool = allWords.filter(w => !missedWordIds.includes(w._id!));
+
+  const questions: RequizQuestion[] = missedWords.map(targetWord => {
+    // Pick up to 3 distractors from other words in the session
+    const distractors = shuffle(distractorPool)
+      .slice(0, 3)
+      .map(dw => ({
+        word: dw.word,
+        phoneticNotation: dw.phoneticNotation,
+        isCorrect: false,
+      }));
+
+    const correctOption: RequizOption = {
+      word: targetWord.word,
+      phoneticNotation: targetWord.phoneticNotation,
+      isCorrect: true,
+    };
+
+    // Shuffle correct + distractors together (Approach 1: option shuffle)
+    const options = shuffle([correctOption, ...distractors]);
+
+    return {
+      stem: targetWord.definition,
+      correctWord: targetWord.word,
+      correctPhonetic: targetWord.phoneticNotation,
+      options,
+      usedWords: [targetWord._id!],
+    };
+  });
+
+  return shuffle(questions);
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -128,7 +128,8 @@
     "fantastic-job-keep-it-up": "Fantastische Arbeit, mach weiter so!",
     "try-again": "Erneut versuchen",
     "you-answered-correctly": "Du hast {count} von {total} Fragen richtig beantwortet",
-    "go-cards": "Gehen Sie zu Karten"
+    "go-cards": "Gehen Sie zu Karten",
+    "requiz-summary": "{correct} von {total} falschen Wörtern richtig wiederholt"
   },
   "word-card": {
     "definition": "Definition",
@@ -340,5 +341,16 @@
     "generating": "Quiz wird erstellt...",
     "loading-words": "Woerter werden geladen...",
     "error-fetching-words": "Fehler beim Laden der Woerter"
+  },
+  "requiz": {
+    "review-missed-words": "Falsche Wörter wiederholen",
+    "which-word-means": "Welches Wort bedeutet: {definition}?",
+    "correct": "Richtig!",
+    "incorrect": "Nicht ganz",
+    "correct-answer-was": "Super! Die Antwort war {word}.",
+    "correct-answer-is": "Die richtige Antwort ist {word}.",
+    "continue": "Weiter",
+    "finish-review": "Wiederholung beenden",
+    "question": "Wiederholung {current}/{total}"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -194,7 +194,8 @@
     "fantastic-job-keep-it-up": "Fantastic job, keep it up!!",
     "try-again": "Try again",
     "you-answered-correctly": "You answered correctly {count} of {total} questions",
-    "go-cards": "Go to Cards"
+    "go-cards": "Go to Cards",
+    "requiz-summary": "Reviewed {correct} of {total} missed words correctly"
   },
   "word-card": {
     "definition": "Definition",
@@ -341,5 +342,16 @@
     "generating": "Generating quiz...",
     "loading-words": "Loading word pool...",
     "error-fetching-words": "Error fetching words"
+  },
+  "requiz": {
+    "review-missed-words": "Review missed words",
+    "which-word-means": "Which word means: {definition}?",
+    "correct": "Correct!",
+    "incorrect": "Not quite",
+    "correct-answer-was": "You got it! The answer was {word}.",
+    "correct-answer-is": "The correct answer is {word}.",
+    "continue": "Continue",
+    "finish-review": "Finish review",
+    "question": "Review {current}/{total}"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -129,7 +129,8 @@
     "fantastic-job-keep-it-up": "¡Fantástico trabajo, sigue así!",
     "try-again": "Intentar de nuevo",
     "you-answered-correctly": "Respondiste correctamente a {count} de {total} preguntas",
-    "go-cards": "Ir a cartas"
+    "go-cards": "Ir a cartas",
+    "requiz-summary": "Repasadas correctamente {correct} de {total} palabras falladas"
   },
   "word-card": {
     "definition": "Definición",
@@ -341,5 +342,16 @@
     "generating": "Generando quiz...",
     "loading-words": "Cargando palabras...",
     "error-fetching-words": "Error al cargar palabras"
+  },
+  "requiz": {
+    "review-missed-words": "Repasar palabras falladas",
+    "which-word-means": "¿Qué palabra significa: {definition}?",
+    "correct": "¡Correcto!",
+    "incorrect": "No exactamente",
+    "correct-answer-was": "¡Lo tienes! La respuesta era {word}.",
+    "correct-answer-is": "La respuesta correcta es {word}.",
+    "continue": "Continuar",
+    "finish-review": "Terminar repaso",
+    "question": "Repaso {current}/{total}"
   }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -194,7 +194,8 @@
     "fantastic-job-keep-it-up": "Отличная работа, продолжайте в том же духе!",
     "try-again": "Попробовать снова",
     "you-answered-correctly": "Вы правильно ответили на {count} из {total} вопросов",
-    "go-cards": "Перейти к карточкам"
+    "go-cards": "Перейти к карточкам",
+    "requiz-summary": "Правильно повторено {correct} из {total} пропущенных слов"
   },
   "word-card": {
     "definition": "Определение",
@@ -341,5 +342,16 @@
     "generating": "Создание теста...",
     "loading-words": "Загрузка слов...",
     "error-fetching-words": "Ошибка загрузки слов"
+  },
+  "requiz": {
+    "review-missed-words": "Повторить пропущенные слова",
+    "which-word-means": "Какое слово означает: {definition}?",
+    "correct": "Правильно!",
+    "incorrect": "Не совсем",
+    "correct-answer-was": "Верно! Ответ был {word}.",
+    "correct-answer-is": "Правильный ответ: {word}.",
+    "continue": "Далее",
+    "finish-review": "Завершить повторение",
+    "question": "Повторение {current}/{total}"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -129,7 +129,8 @@
     "fantastic-job-keep-it-up": "太棒了，继续保持！",
     "try-again": "再试一次",
     "you-answered-correctly": "你答对了 {total} 道题中的 {count} 道",
-    "go-cards": "去卡"
+    "go-cards": "去卡",
+    "requiz-summary": "正确复习了 {total} 个错词中的 {correct} 个"
   },
   "word-card": {
     "definition": "定义",
@@ -341,5 +342,16 @@
     "generating": "正在生成测验...",
     "loading-words": "正在加载单词...",
     "error-fetching-words": "加载单词时出错"
+  },
+  "requiz": {
+    "review-missed-words": "复习错词",
+    "which-word-means": "哪个词的意思是：{definition}？",
+    "correct": "正确！",
+    "incorrect": "不太对",
+    "correct-answer-was": "答对了！答案是{word}。",
+    "correct-answer-is": "正确答案是{word}。",
+    "continue": "继续",
+    "finish-review": "完成复习",
+    "question": "复习 {current}/{total}"
   }
 }

--- a/src/app/[locale]/quiz/page.tsx
+++ b/src/app/[locale]/quiz/page.tsx
@@ -12,6 +12,7 @@ import LoadingComponent from '@/components/Layout/LoadingComponent';
 import QuizFinished from '@/components/Quiz/QuizFinished';
 import QuizStartCard from '@/components/Quiz/QuizStartCard';
 import QuizView from '@/components/Quiz/QuizView';
+import RequizView from '@/components/Quiz/RequizView';
 import type { User, Word, Language } from '@/types/Words';
 import { QuizComposition } from '@/types/Quiz';
 import { getUserData, getWordsForQuiz } from '@/lib/apis';
@@ -54,6 +55,15 @@ const QuizPage = () => {
     displayQuiz,
     composition: quizComposition,
     handleDeleteQuiz,
+    // Requiz
+    isRequizPhase,
+    currentRequizQuestion,
+    requizScore,
+    requizFeedback,
+    requizProgress,
+    handleRequizAnswerClick,
+    handleRequizContinue,
+    missedWordIds,
   } = useQuizManager(userData!, { active: mode === 'active' });
 
   useEffect(() => {
@@ -202,6 +212,12 @@ const QuizPage = () => {
       });
   }, [restartQuiz, selectedLanguage.language]);
 
+  // Build requiz summary for the finished screen
+  const requizSummary =
+    missedWordIds.length > 0
+      ? { total: missedWordIds.length, correct: requizScore.correct }
+      : undefined;
+
   if (status === 'loading' || !userData) {
     return <LoadingComponent />;
   }
@@ -239,15 +255,22 @@ const QuizPage = () => {
     return <LoadingComponent message={t('finishing-quiz')} />;
   }
 
-  // TODO: Check why in the onboarding the language selectrion is buggy
-
   return (
-    <main className="min-h-[80vh] flex flex-col items-center justify-center md:justify-start  py-20 px-4 w-full">
+    <main className="min-h-[80vh] flex flex-col items-center justify-center md:justify-start py-20 px-4 w-full">
       {isQuizFinished ? (
         <QuizFinished
           isSuccess={score.success / 2 > score.errors}
           successPoints={score}
           onRestartQuiz={handleRestartQuiz}
+          requizSummary={requizSummary}
+        />
+      ) : isRequizPhase && currentRequizQuestion ? (
+        <RequizView
+          question={currentRequizQuestion}
+          onAnswerClick={handleRequizAnswerClick}
+          feedback={requizFeedback}
+          onContinue={handleRequizContinue}
+          progress={requizProgress}
         />
       ) : (
         <QuizView


### PR DESCRIPTION
- Add lib/requiz.ts: pure utility to build reverse-direction questions from existing Word data (no LLM needed)
- Add RequizView component: renders definition-as-stem questions with target-language word options + phonetic notation
- Extend useQuizManager with requiz phase state tracking: missed word IDs, requiz questions, step, score, feedback
- Update QuizFinished with requiz summary (missed words reviewed)
- Update quiz page to render RequizView during requiz phase
- Add i18n strings for requiz UI in all 5 locales (en, es, de, zh, ru)
- Add tests for buildRequizQuestions utility (10 test cases)

Scientific basis: Errorful learning + corrective feedback (Metcalfe 2017, Richland et al. 2007). Re-testing on errors after a short delay with a reverse question direction (L1->L2) converts failures into learning events at the moment of maximum attention.