### PR TITLE
feat: add error-driven requiz with reverse direction (L1->L2)

### DIFF
--- a/components/Quiz/QuizFinished.tsx
+++ b/components/Quiz/QuizFinished.tsx
@@ -8,9 +8,10 @@ interface Props {
   isSuccess: boolean;
   successPoints: { errors: number; success: number };
   onRestartQuiz?: () => void;
+  requizSummary?: { correct: number; total: number };
 }
 
-const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
+const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz, requizSummary }: Props) => {
   const { triggerFireworks, triggerSchoolPride, resetConfetti } = useConfetti();
   const t = useTranslations('quiz-finished');
   const router = useRouter();
@@ -41,16 +42,14 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
   };
 
   return (
-    // Use theme-bg-light and theme-bg-dark for the background
     <div className="flex items-center w-full md:my-20 justify-center bg-theme-bg-light dark:bg-theme-bg-dark relative overflow-hidden">
       <AnimatePresence mode="wait">
         {isSuccess ? (
           <motion.div
             key="success-card"
-            // Use theme-fg-light/dark for card background and theme-text-light/dark for general text
             className="rounded-3xl p-6 md:p-8 text-center max-w-md w-full relative transform transition-all duration-500 hover:scale-101
-                       bg-theme-fg-light text-theme-text-light
-                       dark:bg-theme-fg-dark dark:text-theme-text-dark"
+ bg-theme-fg-light text-theme-text-light
+ dark:bg-theme-fg-dark dark:text-theme-text-dark"
             variants={cardVariants}
             initial="hidden"
             animate="visible"
@@ -59,7 +58,7 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
             <h1 className="text-3xl font-extrabold text-secondary mb-4 drop-shadow-lg animate-bounce-short">
               {t('congratulations')}!
             </h1>
-            <p className="text-xl  font-semibold mb-6 leading-tight">
+            <p className="text-xl font-semibold mb-6 leading-tight">
               {t('you-answered-correctly', { count: successPoints.success, total: totalQuestions })}
             </p>
             <div className="w-24 h-24 mx-auto mb-6 bg-secondary/20 rounded-full flex items-center justify-center shadow-inner">
@@ -67,6 +66,14 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
                 {Math.round(percentageCorrect)}%
               </span>
             </div>
+            {requizSummary && requizSummary.total > 0 && (
+              <p className="text-sm text-amber-600 dark:text-amber-400 mb-4">
+                {t('requiz-summary', {
+                  correct: requizSummary.correct,
+                  total: requizSummary.total,
+                })}
+              </p>
+            )}
             <p className="text-lg mb-8">{t('fantastic-job-keep-it-up')}</p>
             <button
               onClick={onGoToCards}
@@ -79,8 +86,8 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
           <motion.div
             key="failure-card"
             className="rounded-3xl p-6 md:p-8 text-center max-w-md w-full relative transform transition-all duration-500 hover:scale-101
-                       bg-theme-fg-light text-theme-text-light
-                       dark:bg-theme-fg-dark dark:text-theme-text-dark"
+ bg-theme-fg-light text-theme-text-light
+ dark:bg-theme-fg-dark dark:text-theme-text-dark"
             variants={cardVariants}
             initial="hidden"
             animate="visible"
@@ -97,6 +104,14 @@ const QuizFinished = ({ isSuccess, successPoints, onRestartQuiz }: Props) => {
                 {Math.round(percentageCorrect)}%
               </span>
             </div>
+            {requizSummary && requizSummary.total > 0 && (
+              <p className="text-sm text-amber-600 dark:text-amber-400 mb-4">
+                {t('requiz-summary', {
+                  correct: requizSummary.correct,
+                  total: requizSummary.total,
+                })}
+              </p>
+            )}
             <p className="text-lg mb-8">{t('dont-give-up-try-again')}</p>
             {onRestartQuiz && (
               <button

--- a/components/Quiz/RequizView.tsx
+++ b/components/Quiz/RequizView.tsx
@@ -1,0 +1,100 @@
+import { useTranslations } from 'next-intl';
+import { RequizQuestion, RequizOption } from '@/lib/requiz';
+
+interface Props {
+  question: RequizQuestion;
+  onAnswerClick: (option: RequizOption) => void;
+  feedback: 'correct' | 'wrong' | null;
+  onContinue: () => void;
+  progress: { current: number; total: number };
+}
+
+const RequizView = ({ question, onAnswerClick, feedback, onContinue, progress }: Props) => {
+  const t = useTranslations('requiz');
+
+  if (!question) return null;
+
+  const hasAnswered = feedback !== null;
+
+  return (
+    <div className="flex flex-col gap-5 w-full max-w-md" aria-live="polite">
+      {/* Requiz header */}
+      <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
+        <span className="w-2 h-2 rounded-full bg-amber-500" />
+        {t('review-missed-words')}
+      </div>
+
+      {/* Question stem = definition in native language */}
+      <p className="text-xl font-semibold">{question.stem}</p>
+
+      {/* Answer options = target-language words */}
+      <ul className="flex w-full flex-col gap-4">
+        {question.options.map(option => (
+          <li
+            key={option.word}
+            onClick={() => !hasAnswered && onAnswerClick(option)}
+            onKeyDown={e =>
+              !hasAnswered && (e.key === 'Enter' || e.key === ' ') && onAnswerClick(option)
+            }
+            role="button"
+            tabIndex={hasAnswered ? -1 : 0}
+            className={`cursor-pointer flex flex-col items-start list-none py-2 px-5 rounded-md transition-colors
+              dark:bg-theme-fg-dark bg-theme-fg-light
+              ${!hasAnswered ? 'hover:bg-secondary' : ''}
+              ${hasAnswered && option.isCorrect ? 'blink-success' : ''}
+              ${hasAnswered ? 'pointer-events-none' : ''}`}
+          >
+            <span className="text-lg font-medium">{option.word}</span>
+            {option.phoneticNotation && (
+              <span className="text-sm font-extralight italic opacity-70">
+                {option.phoneticNotation}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {/* Feedback message */}
+      {hasAnswered && (
+        <div
+          className={`py-3 px-4 rounded-lg border-l-4 text-sm leading-relaxed ${
+            feedback === 'correct'
+              ? 'bg-green-50 dark:bg-green-900/20 border-green-400 dark:border-green-600 text-green-800 dark:text-green-200'
+              : 'bg-red-50 dark:bg-red-900/20 border-red-400 dark:border-red-600 text-red-800 dark:text-red-200'
+          }`}
+        >
+          <p className="font-semibold">
+            {feedback === 'correct' ? t('you-got-it') : t('correct-answer-was')}
+          </p>
+          {feedback === 'wrong' && (
+            <p className="mt-1">
+              <span className="font-bold">{question.correctWord}</span>
+              {question.correctPhonetic && (
+                <span className="ml-2 italic opacity-70">{question.correctPhonetic}</span>
+              )}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Continue button */}
+      {hasAnswered && (
+        <button
+          onClick={onContinue}
+          className="w-full py-2 px-4 rounded-md font-medium transition-colors bg-primary bg-info cursor-pointer hover:bg-info/80 text-white hover:bg-primary/90 active:bg-primary/80"
+        >
+          {t('continue')}
+        </button>
+      )}
+
+      {/* Progress */}
+      <section className="flex justify-between gap-0.5">
+        <p className="text-[0.6rem] italic font-extralight opacity-60">
+          {t('progress', { current: progress.current, total: progress.total })}
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default RequizView;

--- a/hooks/__tests__/useQuizManager.test.tsx
+++ b/hooks/__tests__/useQuizManager.test.tsx
@@ -57,6 +57,10 @@ vi.mock('@/lib/helpers', () => ({
   shuffleArray: (arr: any[]): any[] => [...arr],
 }));
 
+vi.mock('@/lib/requiz', () => ({
+  buildRequizQuestions: () => [],
+}));
+
 // --- Mock Data ---
 
 const mockWord1 = {

--- a/hooks/useQuizManager.tsx
+++ b/hooks/useQuizManager.tsx
@@ -9,6 +9,7 @@ import { saveQuizSession } from '@/lib/apis';
 import { Quiz, QuizAnswer } from '@/types/Quiz';
 import { User, Word } from '@/types/Words';
 import { shuffleArray } from '@/lib/helpers';
+import { buildRequizQuestions, RequizOption, RequizQuestion } from '@/lib/requiz';
 
 interface UseQuizManagerOptions {
   active?: boolean;
@@ -43,6 +44,14 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
   const [showingExplanation, setShowingExplanation] = useState(false);
   const [isFinishing, setIsFinishing] = useState(false);
   const [startingTimer, setStartingTimer] = useState<number>();
+
+  // Requiz state
+  const [missedWordIds, setMissedWordIds] = useState<string[]>([]);
+  const [isRequizPhase, setIsRequizPhase] = useState(false);
+  const [requizQuestions, setRequizQuestions] = useState<RequizQuestion[]>([]);
+  const [requizStep, setRequizStep] = useState(0);
+  const [requizScore, setRequizScore] = useState({ correct: 0, total: 0 });
+  const [requizFeedback, setRequizFeedback] = useState<'correct' | 'wrong' | null>(null);
 
   const originalEaseFactors = useRef<Map<string, number>>(new Map());
   const quizStartTime = useRef(Date.now());
@@ -117,12 +126,30 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
   ]);
 
   // Effect to handle the end of the quiz
-  // Quiz only truly finishes when ALL quizzes are ready AND the user has answered all of them
+  // Quiz finishes after the main quiz AND any requiz phase is complete
   useEffect(() => {
     if (isQuizFinished || !session) return;
     if (isFinishingRef.current) return;
+    // Don't finish while requiz is active
+    if (isRequizPhase) return;
+    // Only finish when user has answered all main quiz questions
+    // AND either requiz is done or there were no errors
+    const mainQuizDone = displayQuiz.length && quizStep >= displayQuiz.length && userData;
+    const requizDone = !isRequizPhase;
+    if (mainQuizDone && requizDone) {
+      // If there are missed words and requiz hasn't started yet, start it
+      if (missedWordIds.length > 0 && requizQuestions.length === 0) {
+        const questions = buildRequizQuestions(missedWordIds, usedWords);
+        if (questions.length > 0) {
+          setRequizQuestions(questions);
+          setIsRequizPhase(true);
+          setRequizStep(0);
+          setRequizScore({ correct: 0, total: 0 });
+          setRequizFeedback(null);
+          return; // Don't finish yet — requiz will run
+        }
+      }
 
-    if (displayQuiz.length && quizStep >= displayQuiz.length && userData) {
       isFinishingRef.current = true;
       setIsFinishing(true);
 
@@ -184,6 +211,9 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     deleteValue,
     isQuizFinished,
     isAllQuizzesReady,
+    isRequizPhase,
+    missedWordIds,
+    requizQuestions,
   ]);
 
   const handleAnswerClick = useCallback(
@@ -200,6 +230,10 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
       } else {
         setScore(prev => ({ ...prev, errors: prev.errors + 1 }));
         setFeedback({ correct: '', wrong: option.answer });
+        // Track missed words for requiz
+        for (const wordId of currentQuestion.usedWords) {
+          setMissedWordIds(prev => (prev.includes(wordId) ? prev : [...prev, wordId]));
+        }
       }
 
       setUsedWords(prev => {
@@ -254,6 +288,49 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     }
   }, [displayQuiz, quizStep, questionStep]);
 
+  const handleRequizAnswerClick = useCallback(
+    (option: RequizOption) => {
+      const currentRequizQ = requizQuestions[requizStep];
+      if (!currentRequizQ) return;
+
+      if (option.isCorrect) {
+        setRequizScore(prev => ({ ...prev, correct: prev.correct + 1, total: prev.total + 1 }));
+        setRequizFeedback('correct');
+      } else {
+        setRequizScore(prev => ({ ...prev, total: prev.total + 1 }));
+        setRequizFeedback('wrong');
+      }
+
+      // Update SRS for the requiz word
+      setUsedWords(prev => {
+        const wordMap = new Map(prev.map(w => [w._id!, w]));
+        for (const wordId of currentRequizQ.usedWords) {
+          const word = wordMap.get(wordId);
+          if (!word) continue;
+          const originalEase = originalEaseFactors.current.get(wordId);
+          const updatedWord = processAnswer(word, option.isCorrect, originalEase);
+          wordMap.set(wordId, updatedWord);
+        }
+        return Array.from(wordMap.values());
+      });
+    },
+    [requizQuestions, requizStep]
+  );
+
+  const handleRequizContinue = useCallback(() => {
+    setRequizFeedback(null);
+
+    if (requizStep < requizQuestions.length - 1) {
+      setRequizStep(prev => prev + 1);
+    } else {
+      // Requiz complete — clear state so the finish effect fires
+      setIsRequizPhase(false);
+      setMissedWordIds([]);
+      setRequizQuestions([]);
+      setRequizStep(0);
+    }
+  }, [requizStep, requizQuestions.length]);
+
   const restartQuiz = () => {
     setQuizStep(0);
     setQuestionStep(0);
@@ -261,6 +338,13 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     setIsFinishing(false);
     isFinishingRef.current = false;
     setScore({ errors: 0, success: 0 });
+    // Reset requiz state
+    setMissedWordIds([]);
+    setIsRequizPhase(false);
+    setRequizQuestions([]);
+    setRequizStep(0);
+    setRequizScore({ correct: 0, total: 0 });
+    setRequizFeedback(null);
 
     const allWordIds = [
       ...new Set(displayQuiz.flatMap(q => q.questions.flatMap(question => question.usedWords))),
@@ -289,6 +373,7 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
 
   const currentQuizItem = displayQuiz[quizStep];
   const currentQuestion = currentQuizItem?.questions[questionStep];
+  const currentRequizQuestion = isRequizPhase ? requizQuestions[requizStep] : null;
 
   return {
     isLoading: isLoading || isGeneratingQuiz,
@@ -308,5 +393,14 @@ export const useQuizManager = (userData: User, options?: UseQuizManagerOptions) 
     handleContinue,
     restartQuiz,
     handleDeleteQuiz,
+    // Requiz
+    isRequizPhase,
+    requizQuestions,
+    currentRequizQuestion,
+    requizStep,
+    requizScore,
+    requizFeedback,
+    handleRequizAnswerClick,
+    handleRequizContinue,
   };
 };

--- a/lib/__tests__/requiz.test.ts
+++ b/lib/__tests__/requiz.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequizQuestions } from '@/lib/requiz';
+import { Word } from '@/types/Words';
+
+const makeWord = (id: string, word: string, definition: string, phonetic = ''): Word =>
+  ({
+    _id: id,
+    word,
+    definition,
+    phoneticNotation: phonetic,
+    language: 'English',
+    tags: [],
+    repetitions: 0,
+    interval: 1,
+    easeFactor: 2.5,
+    nextReviewDate: new Date(),
+    userId: 'u1',
+  }) as unknown as Word;
+
+describe('buildRequizQuestions', () => {
+  it('returns empty array when no missed word IDs', () => {
+    const result = buildRequizQuestions([], [makeWord('w1', 'cat', 'gato')]);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when allWords is empty', () => {
+    const result = buildRequizQuestions(['w1'], []);
+    expect(result).toEqual([]);
+  });
+
+  it('builds a question for a single missed word', () => {
+    const words = [
+      makeWord('w1', 'cat', 'gato', 'kæt'),
+      makeWord('w2', 'dog', 'perro', 'dɔg'),
+      makeWord('w3', 'bird', 'pájaro'),
+      makeWord('w4', 'fish', 'pez'),
+    ];
+    const result = buildRequizQuestions(['w1'], words);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].stem).toBe('gato');
+    expect(result[0].correctWord).toBe('cat');
+    expect(result[0].correctPhonetic).toBe('kæt');
+    expect(result[0].usedWords).toEqual(['w1']);
+
+    // Correct option exists
+    const correctOption = result[0].options.find(o => o.isCorrect);
+    expect(correctOption).toBeDefined();
+    expect(correctOption!.word).toBe('cat');
+    expect(correctOption!.phoneticNotation).toBe('kæt');
+
+    // Has distractors from other words
+    const distractors = result[0].options.filter(o => !o.isCorrect);
+    expect(distractors.length).toBeGreaterThan(0);
+  });
+
+  it('builds questions for multiple missed words', () => {
+    const words = [
+      makeWord('w1', 'cat', 'gato'),
+      makeWord('w2', 'dog', 'perro'),
+      makeWord('w3', 'bird', 'pájaro'),
+      makeWord('w4', 'fish', 'pez'),
+    ];
+    const result = buildRequizQuestions(['w1', 'w2'], words);
+
+    expect(result).toHaveLength(2);
+
+    const stems = result.map(q => q.stem);
+    expect(stems).toContain('gato');
+    expect(stems).toContain('perro');
+  });
+
+  it('uses only non-missed words as distractors', () => {
+    const words = [
+      makeWord('w1', 'cat', 'gato'),
+      makeWord('w2', 'dog', 'perro'),
+      makeWord('w3', 'bird', 'pájaro'),
+    ];
+    const result = buildRequizQuestions(['w1', 'w2'], words);
+
+    // For w1 question, distractors should only come from w3
+    const w1Question = result.find(q => q.usedWords.includes('w1'));
+    expect(w1Question).toBeDefined();
+    const distractors = w1Question!.options.filter(o => !o.isCorrect);
+    for (const d of distractors) {
+      expect(d.word).toBe('bird'); // only non-missed word
+    }
+  });
+
+  it('handles single missed word with no other words gracefully', () => {
+    const words = [makeWord('w1', 'cat', 'gato')];
+    const result = buildRequizQuestions(['w1'], words);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].options).toHaveLength(1); // only correct, no distractors
+    expect(result[0].options[0].isCorrect).toBe(true);
+  });
+
+  it('each question has exactly one correct option', () => {
+    const words = [
+      makeWord('w1', 'cat', 'gato'),
+      makeWord('w2', 'dog', 'perro'),
+      makeWord('w3', 'bird', 'pájaro'),
+      makeWord('w4', 'fish', 'pez'),
+    ];
+    const result = buildRequizQuestions(['w1', 'w2', 'w3'], words);
+
+    for (const q of result) {
+      const correctCount = q.options.filter(o => o.isCorrect).length;
+      expect(correctCount).toBe(1);
+    }
+  });
+
+  it('limits distractors to at most 3 per question', () => {
+    const words = [
+      makeWord('w1', 'cat', 'gato'),
+      makeWord('w2', 'dog', 'perro'),
+      makeWord('w3', 'bird', 'pájaro'),
+      makeWord('w4', 'fish', 'pez'),
+      makeWord('w5', 'tree', 'árbol'),
+      makeWord('w6', 'water', 'agua'),
+    ];
+    const result = buildRequizQuestions(['w1'], words);
+
+    expect(result).toHaveLength(1);
+    const distractors = result[0].options.filter(o => !o.isCorrect);
+    expect(distractors.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/lib/requiz.ts
+++ b/lib/requiz.ts
@@ -1,0 +1,78 @@
+import { shuffleArray } from '@/lib/helpers';
+import { Word } from '@/types/Words';
+
+/**
+ * A requiz question built entirely from existing Word data — no LLM needed.
+ * Uses the "Reverse Direction" approach: the stem is the word's definition
+ * (in the user's native language), and options are target-language words.
+ * This shifts the cognitive task from recognition (L2→L1) to productive
+ * recall (L1→L2), which is a harder and more effective encoding operation.
+ *
+ * Option Shuffle is baked in: distractors are drawn from the full session
+ * word pool, not the original question, destroying positional cues.
+ */
+export interface RequizQuestion {
+  /** The definition of the target word, used as the question stem */
+  stem: string;
+  /** The correct target-language word */
+  correctWord: string;
+  /** Phonetic notation for the correct word */
+  correctPhonetic: string;
+  /** All options (including correct), already shuffled */
+  options: RequizOption[];
+  /** Word IDs this requiz question targets */
+  usedWords: string[];
+}
+
+export interface RequizOption {
+  word: string;
+  phoneticNotation: string;
+  isCorrect: boolean;
+}
+
+/**
+ * Builds reverse-direction requiz questions for missed words.
+ *
+ * For each missed word:
+ * - Stem = word's definition (native language)
+ * - Correct option = the target-language word + its phonetic notation
+ * - Distractors = other words from the same quiz session (shuffled)
+ *
+ * @param missedWordIds - IDs of words the user answered incorrectly
+ * @param allWords - All Word objects used in the quiz session
+ * @returns RequizQuestion array (one per missed word), shuffled
+ */
+export function buildRequizQuestions(missedWordIds: string[], allWords: Word[]): RequizQuestion[] {
+  if (missedWordIds.length === 0) return [];
+
+  const missedWords = allWords.filter(w => missedWordIds.includes(w._id!));
+  const distractorPool = shuffleArray(allWords.filter(w => !missedWordIds.includes(w._id!)));
+
+  const questions: RequizQuestion[] = missedWords.map(targetWord => {
+    // Pick up to 3 distractors from other words in the session
+    const distractors = distractorPool.slice(0, 3).map(dw => ({
+      word: dw.word,
+      phoneticNotation: dw.phoneticNotation,
+      isCorrect: false,
+    }));
+
+    const correctOption: RequizOption = {
+      word: targetWord.word,
+      phoneticNotation: targetWord.phoneticNotation,
+      isCorrect: true,
+    };
+
+    // Shuffle correct + distractors together
+    const options = shuffleArray([correctOption, ...distractors]);
+
+    return {
+      stem: targetWord.definition,
+      correctWord: targetWord.word,
+      correctPhonetic: targetWord.phoneticNotation,
+      options,
+      usedWords: [targetWord._id!],
+    };
+  });
+
+  return shuffleArray(questions);
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -128,7 +128,8 @@
     "fantastic-job-keep-it-up": "Fantastische Arbeit, mach weiter so!",
     "try-again": "Erneut versuchen",
     "you-answered-correctly": "Du hast {count} von {total} Fragen richtig beantwortet",
-    "go-cards": "Gehen Sie zu Karten"
+    "go-cards": "Gehen Sie zu Karten",
+    "requiz-summary": "{correct} von {total} falschen Woertern richtig wiederholt"
   },
   "word-card": {
     "definition": "Definition",
@@ -340,5 +341,12 @@
     "generating": "Quiz wird erstellt...",
     "loading-words": "Woerter werden geladen...",
     "error-fetching-words": "Fehler beim Laden der Woerter"
+  },
+  "requiz": {
+    "review-missed-words": "Falsche Woerter wiederholen",
+    "you-got-it": "Richtig!",
+    "correct-answer-was": "Die richtige Antwort war:",
+    "continue": "Weiter",
+    "progress": "Frage {current}/{total}"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -194,7 +194,8 @@
     "fantastic-job-keep-it-up": "Fantastic job, keep it up!!",
     "try-again": "Try again",
     "you-answered-correctly": "You answered correctly {count} of {total} questions",
-    "go-cards": "Go to Cards"
+    "go-cards": "Go to Cards",
+    "requiz-summary": "Reviewed {correct} of {total} missed words correctly"
   },
   "word-card": {
     "definition": "Definition",
@@ -341,5 +342,12 @@
     "generating": "Generating quiz...",
     "loading-words": "Loading word pool...",
     "error-fetching-words": "Error fetching words"
+  },
+  "requiz": {
+    "review-missed-words": "Review missed words",
+    "you-got-it": "You got it!",
+    "correct-answer-was": "The correct answer was:",
+    "continue": "Continue",
+    "progress": "Question {current}/{total}"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -129,7 +129,8 @@
     "fantastic-job-keep-it-up": "¡Fantástico trabajo, sigue así!",
     "try-again": "Intentar de nuevo",
     "you-answered-correctly": "Respondiste correctamente a {count} de {total} preguntas",
-    "go-cards": "Ir a cartas"
+    "go-cards": "Ir a cartas",
+    "requiz-summary": "Repasadas {correct} de {total} palabras falladas correctamente"
   },
   "word-card": {
     "definition": "Definición",
@@ -341,5 +342,12 @@
     "generating": "Generando quiz...",
     "loading-words": "Cargando palabras...",
     "error-fetching-words": "Error al cargar palabras"
+  },
+  "requiz": {
+    "review-missed-words": "Repasar palabras falladas",
+    "you-got-it": "Lo tienes!",
+    "correct-answer-was": "La respuesta correcta era:",
+    "continue": "Continuar",
+    "progress": "Pregunta {current}/{total}"
   }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -194,7 +194,8 @@
     "fantastic-job-keep-it-up": "Отличная работа, продолжайте в том же духе!",
     "try-again": "Попробовать снова",
     "you-answered-correctly": "Вы правильно ответили на {count} из {total} вопросов",
-    "go-cards": "Перейти к карточкам"
+    "go-cards": "Перейти к карточкам",
+    "requiz-summary": "Правильно повторено {correct} из {total} пропущенных слов"
   },
   "word-card": {
     "definition": "Определение",
@@ -341,5 +342,12 @@
     "generating": "Создание теста...",
     "loading-words": "Загрузка слов...",
     "error-fetching-words": "Ошибка загрузки слов"
+  },
+  "requiz": {
+    "review-missed-words": "Повторить пропущенные слова",
+    "you-got-it": "Правильно!",
+    "correct-answer-was": "Правильный ответ:",
+    "continue": "Далее",
+    "progress": "Вопрос {current}/{total}"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -129,7 +129,8 @@
     "fantastic-job-keep-it-up": "太棒了，继续保持！",
     "try-again": "再试一次",
     "you-answered-correctly": "你答对了 {total} 道题中的 {count} 道",
-    "go-cards": "去卡"
+    "go-cards": "去卡",
+    "requiz-summary": "正确复习了 {total} 个错词中的 {correct} 个"
   },
   "word-card": {
     "definition": "定义",
@@ -341,5 +342,12 @@
     "generating": "正在生成测验...",
     "loading-words": "正在加载单词...",
     "error-fetching-words": "加载单词时出错"
+  },
+  "requiz": {
+    "review-missed-words": "复习错题",
+    "you-got-it": "答对了！",
+    "correct-answer-was": "正确答案是：",
+    "continue": "继续",
+    "progress": "第 {current}/{total} 题"
   }
 }

--- a/src/app/[locale]/quiz/page.tsx
+++ b/src/app/[locale]/quiz/page.tsx
@@ -12,6 +12,7 @@ import LoadingComponent from '@/components/Layout/LoadingComponent';
 import QuizFinished from '@/components/Quiz/QuizFinished';
 import QuizStartCard from '@/components/Quiz/QuizStartCard';
 import QuizView from '@/components/Quiz/QuizView';
+import RequizView from '@/components/Quiz/RequizView';
 import type { User, Word, Language } from '@/types/Words';
 import { QuizComposition } from '@/types/Quiz';
 import { getUserData, getWordsForQuiz } from '@/lib/apis';
@@ -54,6 +55,15 @@ const QuizPage = () => {
     displayQuiz,
     composition: quizComposition,
     handleDeleteQuiz,
+    // Requiz
+    isRequizPhase,
+    currentRequizQuestion,
+    requizStep,
+    requizQuestions,
+    requizScore,
+    requizFeedback,
+    handleRequizAnswerClick,
+    handleRequizContinue,
   } = useQuizManager(userData!, { active: mode === 'active' });
 
   useEffect(() => {
@@ -226,12 +236,25 @@ const QuizPage = () => {
   // TODO: Check why in the onboarding the language selectrion is buggy
 
   return (
-    <main className="min-h-[80vh] flex flex-col items-center justify-center md:justify-start  py-20 px-4 w-full">
+    <main className="min-h-[80vh] flex flex-col items-center justify-center md:justify-start py-20 px-4 w-full">
       {isQuizFinished ? (
         <QuizFinished
           isSuccess={score.success / 2 > score.errors}
           successPoints={score}
           onRestartQuiz={handleRestartQuiz}
+          requizSummary={
+            requizScore.total > 0
+              ? { correct: requizScore.correct, total: requizScore.total }
+              : undefined
+          }
+        />
+      ) : isRequizPhase && currentRequizQuestion ? (
+        <RequizView
+          question={currentRequizQuestion}
+          onAnswerClick={handleRequizAnswerClick}
+          feedback={requizFeedback}
+          onContinue={handleRequizContinue}
+          progress={{ current: requizStep + 1, total: requizQuestions.length }}
         />
       ) : (
         <QuizView


### PR DESCRIPTION
- lib/requiz.ts: buildRequizQuestions() builds reverse-direction questions from Word data
- RequizView component: definition-as-stem + target-language word options
- useQuizManager: missedWordIds tracking, requiz phase, SRS integration
- QuizFinished: requizSummary prop showing review results
- Quiz page: ternary render (QuizFinished | RequizView | QuizView)
- i18n: requiz namespace + requiz-summary in all 5 locales
- Tests: 7 requiz builder tests + useQuizManager mock update